### PR TITLE
Remove unused route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'rails-erd'
+  gem 'traceroute'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,8 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    traceroute (0.5.0)
+      rails (>= 3.0.0)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -201,9 +203,10 @@ DEPENDENCIES
   simplecov
   spring
   sqlite3
+  traceroute
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get 'owners/select' => 'owners#select', as: :owner_select
 
   resources :owners do
-    resources :cats do
+    resources :cats, except: [:index] do
       resources :statuses
     end
   end


### PR DESCRIPTION
Nice project!

I ran `traceroute` and only found one unused route, the `cats#index` you mention in Issue #13. Tests are passing without it, so I think it's safe to remove. Keeping `traceroute` around can't hurt.
